### PR TITLE
AB#2309 Bugfix goToRootTree folding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@austrakka/alcmonavis",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "description": "A packaged version of Christain M. Zmasek's archaeopteryx.js phylogenetic tree viewer",
   "main": "lib/alcmonavispoeschli.js",
   "types": "lib/alcmonavispoeschli.d.ts",

--- a/src/alcmonavispoeschli.ts
+++ b/src/alcmonavispoeschli.ts
@@ -4423,14 +4423,15 @@ export default class alcmonavispoeschli {
     }
     this.root = this.treeData;
     forester.addParents(this.root);
-    if (!this.options?.initialCollapseThreshold  || !this.basicTreeProperties?.externalNodesCount
-        || this.basicTreeProperties?.externalNodesCount > this.options.initialCollapseThreshold) {
-      this.depth_collapse_level = this.options?.initialCollapseDepth || -1;
-    } else {
-      this.depth_collapse_level = -1;
+
+    if( this.options && this.options.initialCollapseDepth && this.options.initialCollapseThreshold
+        && this.basicTreeProperties?.externalNodesCount
+        && this.basicTreeProperties.externalNodesCount > this.options.initialCollapseThreshold)
+    {
+      this.depth_collapse_level = this.options.initialCollapseDepth;
+      forester.collapseToDepth(this.root, this.depth_collapse_level);
+      this.updateDepthCollapseDepthDisplay();
     }
-    forester.collapseToDepth(this.root, this.depth_collapse_level);
-    this.updateDepthCollapseDepthDisplay();
     this.refresh(false);
   };
 


### PR DESCRIPTION
Do not collapse tree when navigating back to root, if tree size is below `initialCollapseThreshold`