### PR TITLE
External node count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@austrakka/alcmonavis",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "description": "A packaged version of Christain M. Zmasek's archaeopteryx.js phylogenetic tree viewer",
   "main": "lib/alcmonavispoeschli.js",
   "types": "lib/alcmonavispoeschli.d.ts",

--- a/src/alcmonavispoeschli.ts
+++ b/src/alcmonavispoeschli.ts
@@ -4373,6 +4373,10 @@ export default class alcmonavispoeschli {
     this.zoomToFit();
   };
 
+  getExternalNodeCount = () => {
+    return this.basicTreeProperties?.externalNodesCount;  
+  }
+  
   calcMaxExtLabel = () => {
     this.maxLabelLength = (this.options && this.options.nodeLabelGap) || 0;
     forester.preOrderTraversal(this.root, (d) => {


### PR DESCRIPTION
Add getExternalNodeCount() function to expose internal variable, so that tree size can be determined.