### PR TITLE
Branch length and node marker functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@austrakka/alcmonavis",
-  "version": "1.0.41",
+  "version": "1.0.42",
   "description": "A packaged version of Christain M. Zmasek's archaeopteryx.js phylogenetic tree viewer",
   "main": "lib/alcmonavispoeschli.js",
   "types": "lib/alcmonavispoeschli.d.ts",

--- a/src/alcmonavispoeschli.ts
+++ b/src/alcmonavispoeschli.ts
@@ -5991,16 +5991,18 @@ export default class alcmonavispoeschli {
     }
     this.update();
   };
-
+  
   confidenceValuesCbClicked = () => {
     this.options!.showConfidenceValues = this.getCheckboxValue(AP.CONFIDENCE_VALUES_CB);
     this.update();
   };
 
-  branchLengthsCbClicked = () => {
-    this.options!.showBranchLengthValues = this.getCheckboxValue(AP.BRANCH_LENGTH_VALUES_CB);
+  // replaces branchLengthsCbClicked
+  setShowBranchLengths = (val: boolean) => {
+    console.log("setShowBranchLengths called, value ",val);
+    this.options!.showBranchLengthValues = val;
     this.update();
-  };
+  }
 
   nodeEventsCbClicked = () => {
     this.options!.showNodeEvents = this.getCheckboxValue(AP.NODE_EVENTS_CB);
@@ -6022,16 +6024,18 @@ export default class alcmonavispoeschli {
     this.update();
   };
 
-  internalNodesCbClicked = () => {
-    this.options!.showInternalNodes = this.getCheckboxValue(AP.INTERNAL_NODES_CB);
+  // replaces internalNodesCbClicked
+  setShowInternalNodes = (val: boolean) => {
+    this.options!.showInternalNodes = val;
     this.update();
   };
-
-  externalNodesCbClicked = () => {
-    this.options!.showExternalNodes = this.getCheckboxValue(AP.EXTERNAL_NODES_CB);
+  
+  // replaces externalNodesCbClicked
+  setShowExternalNodes = (val: boolean) => {
+    this.options!.showExternalNodes = val;
     this.update();
   };
-
+  
   nodeVisCbClicked = () => {
     this.options!.showNodeVisualizations = this.getCheckboxValue(AP.NODE_VIS_CB);
     this.resetVis();


### PR DESCRIPTION
Add functions to toggle branch length display, external and internal node markers. These take booleans and replace the functions which checked built-in archeopteryx controls. For issue 2833.